### PR TITLE
Use dependencies build cache in Docker

### DIFF
--- a/CTF.dockerfile
+++ b/CTF.dockerfile
@@ -1,6 +1,37 @@
 FROM clux/muslrust:nightly
 
 WORKDIR /build
+
+RUN USER=root cargo new --bin base
+COPY ./base/Cargo.toml ./base/Cargo.toml
+
+RUN USER=root cargo new --bin bounded-queue
+COPY ./bounded-queue/Cargo.toml ./bounded-queue/Cargo.toml
+
+RUN USER=root cargo new --bin ctf
+COPY ./ctf/Cargo.toml ./ctf/Cargo.toml
+
+RUN USER=root cargo new --bin ffa
+COPY ./ffa/Cargo.toml ./ffa/Cargo.toml
+
+RUN USER=root cargo new --bin server
+COPY ./server/Cargo.toml ./server/Cargo.toml
+
+RUN USER=root cargo new --bin special-map
+COPY ./special-map/Cargo.toml ./special-map/Cargo.toml
+
+COPY ./Cargo.lock ./Cargo.lock
+COPY ./Cargo.toml ./Cargo.toml
+
+RUN cargo build --release
+
+RUN rm ./base/src/*.rs
+RUN rm ./bounded-queue/src/*.rs
+RUN rm ./ctf/src/*.rs
+RUN rm ./ffa/src/*.rs
+RUN rm ./server/src/*.rs
+RUN rm ./special-map/src/*.rs
+
 COPY . /build
 
 RUN cargo build --release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,37 @@
 FROM clux/muslrust:nightly
 
 WORKDIR /build
+
+RUN USER=root cargo new --bin base
+COPY ./base/Cargo.toml ./base/Cargo.toml
+
+RUN USER=root cargo new --bin bounded-queue
+COPY ./bounded-queue/Cargo.toml ./bounded-queue/Cargo.toml
+
+RUN USER=root cargo new --bin ctf
+COPY ./ctf/Cargo.toml ./ctf/Cargo.toml
+
+RUN USER=root cargo new --bin ffa
+COPY ./ffa/Cargo.toml ./ffa/Cargo.toml
+
+RUN USER=root cargo new --bin server
+COPY ./server/Cargo.toml ./server/Cargo.toml
+
+RUN USER=root cargo new --bin special-map
+COPY ./special-map/Cargo.toml ./special-map/Cargo.toml
+
+COPY ./Cargo.lock ./Cargo.lock
+COPY ./Cargo.toml ./Cargo.toml
+
+RUN cargo build --release
+
+RUN rm ./base/src/*.rs
+RUN rm ./bounded-queue/src/*.rs
+RUN rm ./ctf/src/*.rs
+RUN rm ./ffa/src/*.rs
+RUN rm ./server/src/*.rs
+RUN rm ./special-map/src/*.rs
+
 COPY . /build
 
 RUN cargo build --release

--- a/FFA.dockerfile
+++ b/FFA.dockerfile
@@ -1,6 +1,37 @@
 FROM clux/muslrust:nightly
 
 WORKDIR /build
+
+RUN USER=root cargo new --bin base
+COPY ./base/Cargo.toml ./base/Cargo.toml
+
+RUN USER=root cargo new --bin bounded-queue
+COPY ./bounded-queue/Cargo.toml ./bounded-queue/Cargo.toml
+
+RUN USER=root cargo new --bin ctf
+COPY ./ctf/Cargo.toml ./ctf/Cargo.toml
+
+RUN USER=root cargo new --bin ffa
+COPY ./ffa/Cargo.toml ./ffa/Cargo.toml
+
+RUN USER=root cargo new --bin server
+COPY ./server/Cargo.toml ./server/Cargo.toml
+
+RUN USER=root cargo new --bin special-map
+COPY ./special-map/Cargo.toml ./special-map/Cargo.toml
+
+COPY ./Cargo.lock ./Cargo.lock
+COPY ./Cargo.toml ./Cargo.toml
+
+RUN cargo build --release
+
+RUN rm ./base/src/*.rs
+RUN rm ./bounded-queue/src/*.rs
+RUN rm ./ctf/src/*.rs
+RUN rm ./ffa/src/*.rs
+RUN rm ./server/src/*.rs
+RUN rm ./special-map/src/*.rs
+
 COPY . /build
 
 RUN cargo build --release


### PR DESCRIPTION
I added an intermediate build of empty projects (with all dependencies) so that the downloading and the building of dependencies are independent now and can be cached by Docker. Now, if the dependencies don't change, rebuilding will be much faster.